### PR TITLE
Class MultiRunner implements MultiRunnerInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,29 @@ And then there are three possible use cases:
 2. Run and forget (do nothing) &mdash; ```runAndForget()```;
 3. Run and get the first N results &mdash; ```runAndWaitForTheFirstNthResults()```.
 
+### Dependency inversion during dependency injection
+
+If you need to pass some ```MultiRunner``` child class as a parameter to a constructor or other method,
+it is worth using the ```MultiRunnerInterface``` interface to remove the dependency on a particular class.
+```php
+    public function someMethodInSomeClass(MultiRunnerInterface $runner) {
+        ...
+        $processId = 0;
+        foreach ($params as $param) {
+            $processId++;
+            $runner->addProcess((string)$processId, $param);
+        }
+        $timeToWait = 60;
+        
+        try {
+            $results = $runner->runAndWaitForResults($timeToWait);
+        } catch (RuntimeException $e) {
+            ...
+        }               
+        ...
+    }
+```
+
 ### More examples
 
 [Run one program many times with different parameters and get its messages about the results of its work](docs/OneProgramRunAndWaitForResults.md)

--- a/docs/README.ru.md
+++ b/docs/README.ru.md
@@ -85,6 +85,29 @@
 2. Запустить и забыть (ничего не делать) &mdash; ```runAndForget()```;
 3. Запустить и получить первые N результатов  &mdash; ```runAndWaitForTheFirstNthResults()```.
 
+### Инверсия зависимости при внедрении зависимости
+
+Если нужно передать какой-либо класс-наследник ```MultiRunner``` как параметр в конструктор или другой метод,
+то стоит воспользоваться интерфейсом ```MultiRunnerInterface```, чтобы убрать зависимость от конкретного класса.
+```php
+    public function someMethodInSomeClass(MultiRunnerInterface $runner) {
+        ...
+        $processId = 0;
+        foreach ($params as $param) {
+            $processId++;
+            $runner->addProcess((string)$processId, $param);
+        }
+        $timeToWait = 60;
+        
+        try {
+            $results = $runner->runAndWaitForResults($timeToWait);
+        } catch (RuntimeException $e) {
+            ...
+        }               
+        ...
+    }
+```
+
 ### Другие примеры
 [Запустить одну программу много раз с разными параметрами и получить ее сообщения о результатах работы](OneProgramRunAndWaitForResults.md)
 

--- a/src/MultiRunner.php
+++ b/src/MultiRunner.php
@@ -33,7 +33,7 @@ use JustMisha\MultiRunner\Helpers\OsCommandsWrapper;
  * @psalm-api
  *                              }
  */
-abstract class MultiRunner
+abstract class MultiRunner implements MultiRunnerInterface
 {
     protected const STDIN = 0;
     protected const STDOUT = 1;

--- a/src/MultiRunnerInterface.php
+++ b/src/MultiRunnerInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace JustMisha\MultiRunner;
+
+use JustMisha\MultiRunner\DTO\ProcessResults;
+
+/**
+ * @method addProcess
+ */
+interface MultiRunnerInterface
+{
+    /**
+     * Runs all processes and waits for all process has finished
+     * and their results are returned or the timeout occurs.
+     *
+     * @param integer $waitTime Seconds to wait for results.
+     * @return array<string, ProcessResults>
+     */
+    public function runAndWaitForResults(int $waitTime): array;
+
+    /**
+     * Runs all processes and forget about them.
+     *
+     * There must be no shell redirection in the commandLine field.
+     *
+     * @param integer $waitTime Seconds to wait for results.
+     * @return void
+     */
+    public function runAndForget(int $waitTime): void;
+
+    /**
+     * Runs all processes and waits for
+     * until the $resultsNumberToAwait processes have finished
+     * and their results are returned or the timeout occurs.
+     *
+     * @param integer $waitTime Seconds to wait for results.
+     * @param integer $resultsNumberToAwait How many finished processes to await.
+     * @return array<string, ProcessResults>
+     */
+    public function runAndWaitForTheFirstNthResults(int $waitTime, int $resultsNumberToAwait): array;
+}

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -51,7 +51,7 @@ namespace JustMisha\MultiRunner\Tests {
     class BaseTestCase extends \PHPUnit\Framework\TestCase
     {
 
-        const MAX_PARALLEL_PROCESSES = 100;
+        public const MAX_PARALLEL_PROCESSES = 100;
 
         protected function isWindows(): bool
         {
@@ -80,6 +80,19 @@ namespace JustMisha\MultiRunner\Tests {
                     exec(sprintf("rm -rf %s", escapeshellarg($dir)));
                 }
             }
+        }
+
+        /**
+         * Check whether a base folder clear
+         * after destroying BackgroundParallelProcesses
+         *
+         * @param string $baseFolder
+         * @return void
+         */
+        protected function assertBaseFolderClear(string $baseFolder): void
+        {
+            $dirIterator = new \FilesystemIterator($baseFolder, \FilesystemIterator::SKIP_DOTS);
+            $this->assertFalse($dirIterator->valid());
         }
     }
 }

--- a/tests/Unit/CodeMultiRunnerRunTest.php
+++ b/tests/Unit/CodeMultiRunnerRunTest.php
@@ -395,18 +395,4 @@ HEREDOC;
         $this->assertBaseFolderClear($baseFolder);
 
     }
-
-    /**
-     * Check whether a base folder clear
-     * after destroying BackgroundParallelProcesses
-     *
-     * @param string $baseFolder
-     * @return void
-     */
-    protected function assertBaseFolderClear(string $baseFolder): void
-    {
-        $dirIterator = new \FilesystemIterator($baseFolder, \FilesystemIterator::SKIP_DOTS);
-        $this->assertFalse($dirIterator->valid());
-    }
-
 }

--- a/tests/Unit/MockMultiRunnerRunTest.php
+++ b/tests/Unit/MockMultiRunnerRunTest.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace JustMisha\MultiRunner\Tests\Unit;
+
+
+use JustMisha\MultiRunner\CodeMultiRunner;
+use JustMisha\MultiRunner\DTO\ProcessResults;
+use JustMisha\MultiRunner\MultiRunnerInterface;
+use JustMisha\MultiRunner\Tests\BaseTestCase;
+
+
+class MockMultiRunnerRunTest extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        global $mockMkdir;
+        $mockMkdir = false;
+        global $mockFilePutContents;
+        $mockFilePutContents = false;
+        $this->clearRuntimeFolder();
+    }
+
+    public function testWeCanUseMultiRunnerInterfaceForMocking(): void
+    {
+        $maxParallelProcessNums = 10;
+        $totalProcessNums = 10;
+        $scriptText = '<?php' . PHP_EOL . 'echo "Hahaha";';
+        $baseFolder = dirname(__FILE__, 2) . DIRECTORY_SEPARATOR . 'runtime';
+        $runner = new CodeMultiRunner($maxParallelProcessNums, $scriptText, 'php', [], $baseFolder, null, null);
+
+        for($i = 1; $i <= $totalProcessNums; $i++) {
+            $runner->addProcess((string)$i, (string)$i);
+        }
+        $expectedResult = new ProcessResults(0, 'Hahaha', '');
+        $this->testRunner(60, 10, $expectedResult, $runner);
+        unset($runner);
+        $this->assertBaseFolderClear($baseFolder);
+
+        $runner = new CodeMultiRunner($maxParallelProcessNums, $scriptText, 'php', [], $baseFolder, null, null);
+
+        for($i = 1; $i <= $totalProcessNums; $i++) {
+            $runner->addProcess((string)$i, (string)$i);
+        }
+        $expectedResult = new ProcessResults(0, 'Hahaha', '');
+        $this->testRunner(60, 10, $expectedResult, $runner);
+        unset($runner);
+        $this->assertBaseFolderClear($baseFolder);
+
+        // Create a mock MultiRunner to pass as an argument.
+        $runner = new class() implements MultiRunnerInterface {
+            public function runAndWaitForResults(int $waitTime): array
+            {
+                $array = [];
+                for ($i = 1; $i < 11; $i++) {
+                    $array[$i] = new ProcessResults(0, 'Hahaha', '');
+                }
+                return $array;
+            }
+
+            public function runAndForget(int $waitTime): void
+            {
+                return;
+            }
+
+            public function runAndWaitForTheFirstNthResults(int $waitTime, int $resultsNumberToAwait): array
+            {
+                return [];
+            }
+
+        };
+
+        $expectedResult = new ProcessResults(0, 'Hahaha', '');
+        $this->testRunner(60, 10, $expectedResult, $runner);
+        unset($runner);
+        $this->assertBaseFolderClear($baseFolder);
+    }
+
+    /**
+     * @param int $timeout
+     * @param int $totalProcessNums
+     * @param ProcessResults $expectedResult
+     * @throws \Exception
+     */
+    private function testRunner(
+        int $timeout,
+        int $totalProcessNums,
+        ProcessResults $expectedResult = null,
+        MultiRunnerInterface $runner
+    ): void
+    {
+        if (is_null($expectedResult)) {
+            $expectedResult = new ProcessResults(0, 'Hahaha', '');
+        }
+
+        $results = $runner->runAndWaitForResults($timeout);
+
+        $this->assertCount(($totalProcessNums), $results);
+        $this->assertEquals($expectedResult, $results[1]);
+        $this->assertEquals($expectedResult, $results[$totalProcessNums]);
+    }
+}


### PR DESCRIPTION
To make it possible to refer to an abstract interface instead of a concrete object for dependency injection, and to make it easy to create mock objects of MultiRunner's children.